### PR TITLE
fix: qa-agent fetch 调用添加 AbortController

### DIFF
--- a/qa-agent.mjs
+++ b/qa-agent.mjs
@@ -187,23 +187,30 @@ ${list}
 请判断哪些消息与用户问题真正相关（语义相关即可，不要求字面匹配；如消息谈论的具体事物属于问题所问的范畴，也算相关）。
 只输出 JSON 数组（相关消息的编号，按相关度从高到低），不要其他文字。例如：[3,0,12]`;
 
-  const resp = await fetch(`${config.baseUrl}/chat/completions`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${config.apiKey}` },
-    body: JSON.stringify({
-      model: config.model,
-      messages: [{ role: 'user', content: prompt }],
-      stream: false,
-    }),
-  });
-  if (!resp.ok) throw new Error(`rerank API ${resp.status}`);
-  const data = await resp.json();
-  const text = data.choices?.[0]?.message?.content || '';
-  const m = text.match(/\[[\d,\s]*\]/);
-  if (!m) throw new Error('rerank: no JSON array in response');
-  const order = JSON.parse(m[0]).filter(i => Number.isInteger(i) && i >= 0 && i < candidates.length);
-  if (!order.length) throw new Error('rerank: empty result');
-  return order;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 20000);
+  try {
+    const resp = await fetch(`${config.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${config.apiKey}` },
+      body: JSON.stringify({
+        model: config.model,
+        messages: [{ role: 'user', content: prompt }],
+        stream: false,
+      }),
+      signal: controller.signal,
+    });
+    if (!resp.ok) throw new Error(`rerank API ${resp.status}`);
+    const data = await resp.json();
+    const text = data.choices?.[0]?.message?.content || '';
+    const m = text.match(/\[[\d,\s]*\]/);
+    if (!m) throw new Error('rerank: no JSON array in response');
+    const order = JSON.parse(m[0]).filter(i => Number.isInteger(i) && i >= 0 && i < candidates.length);
+    if (!order.length) throw new Error('rerank: empty result');
+    return order;
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 // ─── Tool execution ────────────────────────────────────────────────────
@@ -360,27 +367,34 @@ async function executeTool(name, args, allMessages, ledger, config, question) {
 
 // ─── LLM call ──────────────────────────────────────────────────────────
 async function callLLM(config, messages) {
-  const resp = await fetch(`${config.baseUrl}/chat/completions`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${config.apiKey}`,
-    },
-    body: JSON.stringify({
-      model: config.model,
-      messages,
-      tools: TOOLS,
-      stream: false,
-    }),
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 28000); // 略小于外层 withTimeout(30s)
+  try {
+    const resp = await fetch(`${config.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${config.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: config.model,
+        messages,
+        tools: TOOLS,
+        stream: false,
+      }),
+      signal: controller.signal,
+    });
 
-  if (!resp.ok) {
-    const text = await resp.text();
-    throw new Error(`LLM API ${resp.status}: ${text.slice(0, 200)}`);
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(`LLM API ${resp.status}: ${text.slice(0, 200)}`);
+    }
+
+    const data = await resp.json();
+    return data.choices?.[0]?.message;
+  } finally {
+    clearTimeout(timeout);
   }
-
-  const data = await resp.json();
-  return data.choices?.[0]?.message;
 }
 
 // ─── Agent conversation loop ───────────────────────────────────────────


### PR DESCRIPTION
## 问题

`qa-agent.mjs` 中 `callLLM` 和 `rerankByLLM` 使用 `fetch` 发起 HTTP 请求，外层用 `withTimeout` 包裹做超时控制。但 `withTimeout` 只是 race 了一个 rejection，底层的 `fetch` 连接并不会被关闭——如果服务端不响应，连接会一直挂着，浪费资源。

## 修复

- ✅ `callLLM`：添加 `AbortController`，28s 超时（略小于外层 `withTimeout(30s)`），确保在外层 timeout 前主动断开
- ✅ `rerankByLLM`：添加 `AbortController`，20s 超时
- ✅ 两者都用 `try/finally` 清理 timeout，防止泄漏