### PR TITLE
Resolve relative dates in the tools instead of in the prompt

### DIFF
--- a/docs/agent-qa.md
+++ b/docs/agent-qa.md
@@ -142,7 +142,7 @@ node scripts/build-qa-index.mjs --group <群名> --all
 
 ### 预处理层
 
-检索前两道过滤，`count_messages` / `search_messages` / `get_recent_messages` 共用：
+检索前三道预处理。前两道 `count_messages` / `search_messages` / `get_recent_messages` 共用；第三道（相对日期解析）刻意跳过 `count_messages`，理由见下。
 
 **① 噪音剔除**（`dropNoise`，规则复用 `lib/text-utils.js` 的 `isNoise`）
 
@@ -169,6 +169,42 @@ node scripts/build-qa-index.mjs --group <群名> --all
 三级匹配逐级放宽，前一级有结果就不再放宽（避免「张三」把「张三丰」也带出来）：别名表精确命中 → `user` 名精确相等 → 子串包含（与原有行为一致，保持兼容）。
 
 文件缺失/损坏/写成数组 → 空表降级，检索行为与加此功能前完全一致。表里写了尚未发言的人则不返回他，不硬造结果。
+
+**③ 相对日期解析**（`lib/relative-dates.js`）
+
+「上周」「最近」「昨天」这类表达原先只在 system prompt 里以文字说明（`"上周" = 上一个完整周(周一到周日)`），由 LLM 自己算成 `dateFrom`/`dateTo`。算错就静默搜错范围 —— README 的历史 benchmark 里记着一次：问「上周分享过什么链接」，Legacy 搜了 `6/8-14` 而答案在 `6/15-21`。
+
+现在 `search_messages` 与 `get_recent_messages` 在模型**没给日期时**，从问题原文解析：
+
+| 表达 | 解析结果 |
+|---|---|
+| 今天 / 昨天 / 前天 / 大前天 | 单日区间 |
+| 上周 / 上礼拜 | 上一个完整周（周一–周日） |
+| 上上周 | 再往前一周 |
+| 本周 / 这周 | 本周一 – 今天（不含未来日期） |
+| 上个月 / 本月 | 自然月边界（跨年、闰月正确） |
+| 最近 / 近期 / 这几天 | 含今天共 7 天 |
+| 最近 N 天 | 含今天共 N 天（1 ≤ N ≤ 365） |
+
+三条设计约束：
+
+- **模型显式给的日期优先**。它可能有比问题字面更好的判断（例如前几轮已用 `count_messages` 探到热点日期）。
+- **解析不出就不限定**。像「前几天」「最近一段时间」这类边界模糊的一律返回 `null` —— 猜错范围比不解析更有害，不解析时模型至少还能从 `dateSpan` 自己挑。
+- **`count_messages` 刻意不参与**。它的用途正是「不限日期探测话题分布在哪些日期」，自动限定会破坏 prompt 里教的「先宽后窄」策略。
+
+工具会在 `dateRange` 回报实际使用的区间，并在自动限定时附 `dateNote`，让模型知道范围是工具替它选的（而不是以为搜了全量）。
+
+#### 顺带修掉的时区 bug
+
+提示词原先用 `new Date().toISOString()` 取「今天」—— 那是 **UTC 日期**，而归档消息的 `time` 字段（`"2026/09/08 07:00:00"`）是**本地时间**。UTC+8 时区在每天 `00:00–08:00` 之间，提示词说的「今天」比归档里的今天早一天，「昨天/最近 7 天」跟着整体偏移：
+
+```
+UTC+8 早上 07:00
+  toISOString() → 2026-09-07   ← 提示词说的"今天"
+  归档 time 字段 → 2026-09-08   ← 实际今天的消息
+```
+
+现在所有日期都走本地字段（`getFullYear` / `getMonth` / `getDate`），与归档 `time` 同一口径。有专门的凌晨时段回归测试。
 
 ### 已知限制
 
@@ -248,6 +284,7 @@ scripts/viewer-server.js    # /api/qa 端点，分发 agent/legacy 模式
 scripts/build-qa-index.mjs  # 离线标注回填（qa-index/）
 scripts/benchmark-qa.js     # 延迟基准（agent vs legacy），不依赖私有数据
 lib/speaker-aliases.js      # 发言人别名解析（tk → tombkeeper）
+lib/relative-dates.js       # 相对日期解析（上周/最近）+ 本地时区锚点
 lib/search-bm25.js          # bigram 分词 + BM25
 lib/chat-chunks.js          # 话题块切分
 lib/chunk-index.js          # 离线标注索引的加载与降级

--- a/lib/relative-dates.js
+++ b/lib/relative-dates.js
@@ -1,0 +1,128 @@
+// 相对日期表达 → 具体日期区间。
+//
+// 为什么要有这一层:原先「上周」「最近」这些表达只在 system prompt 里以文字
+// 说明("上周 = 上一个完整周(周一到周日)"),由 LLM 自己算成 dateFrom/dateTo。
+// 结果是算错就静默搜错范围——README 的历史 benchmark 里记着一次:问「上周分享
+// 过什么链接」,Legacy 模式搜了 6/8-14 而正确答案在 6/15-21。
+//
+// 顺带修掉一个更隐蔽的 bug:提示词原先用 new Date().toISOString() 取"今天",
+// 那是 UTC 日期,而归档消息的 time 字段("2026/09/08 07:00:00")是本地时间。
+// UTC+8 时区在每天 00:00-08:00 之间,提示词说的"今天"比归档里的今天早一天,
+// "昨天/最近 7 天"跟着一起偏。本模块全部走本地日期字段(getFullYear 等)。
+//
+// 参考:Chronos(arXiv 2603.16862)把相对时间表达在索引/检索侧解析成结构化
+// datetime 区间,而非交给模型从字符串推断——其消融显示去掉日期过滤掉 14.7 分。
+'use strict';
+
+/** Date → 本地时区的 YYYY-MM-DD(不能用 toISOString,那是 UTC)。 */
+function localDate(d) {
+    const pad = (n) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+function addDays(d, n) {
+    const out = new Date(d.getTime());
+    out.setDate(out.getDate() + n);
+    return out;
+}
+
+/** 周一为一周之始(中文语境);返回该日期所在周的周一。 */
+function startOfWeek(d) {
+    const day = d.getDay(); // 0=周日
+    const backToMonday = day === 0 ? 6 : day - 1;
+    return addDays(d, -backToMonday);
+}
+
+/**
+ * 解析相对日期表达。
+ *
+ * 刻意只认高频、无歧义的表达。像「前几天」「最近一段时间」这种边界模糊的
+ * 一律不认——猜错范围比不解析更有害(模型至少能从 dateSpan 里自己挑)。
+ *
+ * @param {string} text 用户原始问题
+ * @param {Date} [now] 参照时刻,默认当前;测试用来固定时间
+ * @returns {{dateFrom:string, dateTo:string, label:string}|null}
+ */
+function resolveRelativeRange(text, now = new Date()) {
+    const q = String(text ?? '');
+    const today = localDate(now);
+
+    // 顺序有讲究:「上上周」必须先于「上周」,「前天」先于「天」
+    // 「大前天」先于「前天」,否则前缀会被短模式吞掉。
+    if (/大前天/.test(q)) {
+        const d = localDate(addDays(now, -3));
+        return { dateFrom: d, dateTo: d, label: '大前天' };
+    }
+    if (/前天/.test(q)) {
+        const d = localDate(addDays(now, -2));
+        return { dateFrom: d, dateTo: d, label: '前天' };
+    }
+    if (/昨天|昨日/.test(q)) {
+        const d = localDate(addDays(now, -1));
+        return { dateFrom: d, dateTo: d, label: '昨天' };
+    }
+    if (/今天|今日/.test(q)) {
+        return { dateFrom: today, dateTo: today, label: '今天' };
+    }
+    if (/上上周|上上个?星期/.test(q)) {
+        const monday = addDays(startOfWeek(now), -14);
+        return {
+            dateFrom: localDate(monday),
+            dateTo: localDate(addDays(monday, 6)),
+            label: '上上周(周一至周日)',
+        };
+    }
+    if (/上周|上个?星期|上礼拜/.test(q)) {
+        const monday = addDays(startOfWeek(now), -7);
+        return {
+            dateFrom: localDate(monday),
+            dateTo: localDate(addDays(monday, 6)),
+            label: '上周(周一至周日)',
+        };
+    }
+    if (/本周|这周|这个?星期|这礼拜/.test(q)) {
+        // 本周截止到今天,不含未来日期(归档里也没有)
+        return { dateFrom: localDate(startOfWeek(now)), dateTo: today, label: '本周至今' };
+    }
+    if (/上个?月/.test(q)) {
+        const first = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+        const last = new Date(now.getFullYear(), now.getMonth(), 0); // 上月最后一天
+        return { dateFrom: localDate(first), dateTo: localDate(last), label: '上个月' };
+    }
+    if (/这个?月|本月/.test(q)) {
+        const first = new Date(now.getFullYear(), now.getMonth(), 1);
+        return { dateFrom: localDate(first), dateTo: today, label: '本月至今' };
+    }
+    // 「最近 N 天」优先于笼统的「最近」
+    const nDays = q.match(/最近\s*(\d{1,3})\s*天/);
+    if (nDays) {
+        const n = Math.min(Math.max(Number(nDays[1]), 1), 365);
+        return {
+            dateFrom: localDate(addDays(now, -(n - 1))),
+            dateTo: today,
+            label: `最近 ${n} 天`,
+        };
+    }
+    if (/最近|近期|这几天|这两天/.test(q)) {
+        return { dateFrom: localDate(addDays(now, -6)), dateTo: today, label: '最近 7 天' };
+    }
+    return null;
+}
+
+/**
+ * 给 system prompt 用的时间锚点。全部本地日期,与归档 time 字段同一口径。
+ */
+function timeAnchors(now = new Date()) {
+    const lastWeekMonday = addDays(startOfWeek(now), -7);
+    return {
+        today: localDate(now),
+        yesterday: localDate(addDays(now, -1)),
+        dayBeforeYesterday: localDate(addDays(now, -2)),
+        recentFrom: localDate(addDays(now, -6)),
+        lastWeekFrom: localDate(lastWeekMonday),
+        lastWeekTo: localDate(addDays(lastWeekMonday, 6)),
+        thisWeekFrom: localDate(startOfWeek(now)),
+    };
+}
+
+module.exports = { resolveRelativeRange, timeAnchors, localDate, startOfWeek, addDays };

--- a/scripts/qa-agent.mjs
+++ b/scripts/qa-agent.mjs
@@ -16,11 +16,14 @@ import chunkIndex from '../lib/chunk-index.js';
 import speakerAliases from '../lib/speaker-aliases.js';
 // 噪音判定(红包/签到机器人),与查看器共用同一份规则
 import textUtils from '../lib/text-utils.js';
+// 相对日期表达("上周"/"最近")→ 具体区间;同时提供本地时区的时间锚点
+import relativeDates from '../lib/relative-dates.js';
 
 const { search: bm25Search } = searchBm25;
 const { loadChunkIndex, buildChunksForMessages } = chunkIndex;
 const { loadAliases, resolvePerson, expandPersonTerms } = speakerAliases;
 const { isNoise } = textUtils;
+const { resolveRelativeRange, timeAnchors } = relativeDates;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -135,15 +138,18 @@ const TOOL_SPECS = [
         name: 'get_recent_messages',
         label: '读取时段',
         description:
-            '直接读取某时间段的聊天记录(超过 limit 时均匀采样,保证时间覆盖)。适合"大家在聊什么/总结一下/有什么话题/氛围如何"这类总结归纳型问题——这类问题不要用关键词搜索,直接读记录后归纳。不适合找具体某句话(用 search_messages)。',
+            '直接读取某时间段的聊天记录(超过 limit 时均匀采样,保证时间覆盖)。适合"大家在聊什么/总结一下/有什么话题/氛围如何"这类总结归纳型问题——这类问题不要用关键词搜索,直接读记录后归纳。不适合找具体某句话(用 search_messages)。问题里含"上周/最近/昨天"这类相对表达时可以省略日期,工具会自动解析并在 dateRange 回报实际区间。',
         parameters: {
             type: 'object',
             properties: {
-                dateFrom: { type: 'string', description: '起始日期,格式 YYYY-MM-DD' },
+                dateFrom: {
+                    type: 'string',
+                    description:
+                        '起始日期,格式 YYYY-MM-DD。省略则由工具从问题里解析相对表达(解析不出则读全部)',
+                },
                 dateTo: { type: 'string', description: '结束日期,格式 YYYY-MM-DD' },
                 limit: { type: 'number', description: '最多返回条数,默认120,上限200' },
             },
-            required: ['dateFrom', 'dateTo'],
             additionalProperties: false,
         },
     },
@@ -249,6 +255,26 @@ function filterByDate(msgs, dateFrom, dateTo) {
 function dateSpanOf(msgs) {
     if (!msgs.length) return null;
     return { first: msgDate(msgs[0]), last: msgDate(msgs[msgs.length - 1]) };
+}
+
+/**
+ * 决定本次工具调用实际使用的日期区间。
+ *
+ * 模型显式给了 dateFrom/dateTo 就照用(它可能有比问题字面更好的判断,比如
+ * 前几轮已经用 count_messages 探到热点日期)。两个都没给时,才从问题原文里
+ * 解析相对表达——「上周」这类算错就静默搜错范围,交给确定性代码更可靠。
+ *
+ * 返回的 dateNote 会回给模型,让它知道工具实际用了哪个区间(而不是以为搜了全量)。
+ */
+function resolveDateArgs({ dateFrom, dateTo }, question) {
+    if (dateFrom || dateTo) return { dateFrom, dateTo };
+    const r = resolveRelativeRange(question);
+    if (!r) return { dateFrom, dateTo };
+    return {
+        dateFrom: r.dateFrom,
+        dateTo: r.dateTo,
+        dateNote: `问题含"${r.label}",已自动限定到 ${r.dateFrom} ~ ${r.dateTo}。要换范围请显式传 dateFrom/dateTo`,
+    };
 }
 
 /**
@@ -383,6 +409,7 @@ async function searchByChunks({
     question,
     ledger,
     personNote,
+    dateNote,
     dateFrom,
     dateTo,
     person,
@@ -505,6 +532,7 @@ async function searchByChunks({
         hitIds: hitCitations.slice(0, 8),
         snippets,
         ...(personNote ? { personNote } : {}),
+        ...(dateNote ? { dateNote } : {}),
     };
 }
 
@@ -517,6 +545,7 @@ async function searchFlat({
     question,
     ledger,
     personNote,
+    dateNote,
     dateFrom,
     dateTo,
     person,
@@ -531,6 +560,7 @@ async function searchFlat({
             totalInRange: msgs.length,
             hint: ZERO_HIT_HINT(msgs.length),
             ...(personNote ? { personNote } : {}),
+            ...(dateNote ? { dateNote } : {}),
         };
     }
 
@@ -578,6 +608,7 @@ async function searchFlat({
         hitIds: hitCitations,
         snippets,
         ...(personNote ? { personNote } : {}),
+        ...(dateNote ? { dateNote } : {}),
     };
 }
 
@@ -665,10 +696,12 @@ async function executeTool(name, args, allMessages, ledger, config, question, op
     }
 
     if (name === 'search_messages') {
-        const { person, dateFrom, dateTo } = args;
+        const { person } = args;
         const keywords = normalizeKeywords(args.keywords);
         const invalid = validateDateArgs(args);
         if (invalid) return invalid;
+        // 模型没给日期时从问题原文解析相对表达("上周"/"最近"/"昨天")
+        const { dateFrom, dateTo, dateNote } = resolveDateArgs(args, question);
 
         let msgs = dropNoise(filterByDate(allMessages, dateFrom, dateTo));
         const picked = filterByPerson(msgs, person, opts?.groupDir);
@@ -681,6 +714,7 @@ async function executeTool(name, args, allMessages, ledger, config, question, op
             return {
                 matchCount: 0,
                 totalInRange: 0,
+                ...(dateNote ? { dateNote } : {}),
                 hint: `日期范围 ${dateFrom || '?'} ~ ${dateTo || '?'} 内没有任何消息。可用的日期范围是 ${span?.first} ~ ${span?.last}`,
             };
         }
@@ -697,6 +731,7 @@ async function executeTool(name, args, allMessages, ledger, config, question, op
             question,
             ledger,
             personNote,
+            dateNote,
             dateFrom,
             dateTo,
             person,
@@ -712,9 +747,11 @@ async function executeTool(name, args, allMessages, ledger, config, question, op
     }
 
     if (name === 'get_recent_messages') {
-        const { dateFrom, dateTo, limit } = args;
+        const { limit } = args;
         const invalid = validateDateArgs(args);
         if (invalid) return invalid;
+        // schema 要求 dateFrom/dateTo 必填,但模型偶尔会漏;漏了就从问题里解析
+        const { dateFrom, dateTo, dateNote } = resolveDateArgs(args, question);
         const maxCount = Math.min(limit || 120, 200);
         // 总结型问题直接读原文,噪音不剔会让"大家在聊什么"答成红包和签到
         const msgs = dropNoise(filterByDate(allMessages, dateFrom, dateTo));
@@ -723,7 +760,8 @@ async function executeTool(name, args, allMessages, ledger, config, question, op
             return {
                 total: 0,
                 returned: 0,
-                hint: `日期范围 ${dateFrom} ~ ${dateTo} 内没有任何消息。可用的日期范围是 ${span?.first} ~ ${span?.last}`,
+                ...(dateNote ? { dateNote } : {}),
+                hint: `日期范围 ${dateFrom || '?'} ~ ${dateTo || '?'} 内没有任何消息。可用的日期范围是 ${span?.first} ~ ${span?.last}`,
             };
         }
         // 超出上限时均匀采样而非只取尾部，避免总结型问题的时间偏差
@@ -751,6 +789,9 @@ async function executeTool(name, args, allMessages, ledger, config, question, op
             total: msgs.length,
             returned: sample.length,
             sampled: msgs.length > maxCount,
+            // 回报实际用的区间:模型省略日期时它才知道工具替它选了什么
+            dateRange: `${dateFrom || '?'} ~ ${dateTo || '?'}`,
+            ...(dateNote ? { dateNote } : {}),
             messages: sample.map(formatMessage),
         };
     }
@@ -831,8 +872,11 @@ async function conversationLoop(question, allMessages, config, opts) {
     const toolCallLog = [];
     const startedAt = Date.now();
 
-    const today = new Date().toISOString().split('T')[0];
-    const systemPrompt = `你是一个群聊记录问答助手。今天是 ${today}。
+    // 时间锚点全部走本地日期(与归档 time 字段同口径)。原先用 toISOString()
+    // 取的是 UTC 日期,UTC+8 时区在每天 00:00-08:00 之间会把"今天/昨天"整体
+    // 说早一天,模型据此算出的 dateFrom/dateTo 就系统性偏移。
+    const t = timeAnchors();
+    const systemPrompt = `你是一个群聊记录问答助手。今天是 ${t.today}。
 
 先判断问题类型,选对工具:
 
@@ -855,11 +899,17 @@ async function conversationLoop(question, allMessages, config, opts) {
 - 找不到相关信息时明确告知
 - 用中文回答
 
-时间理解:
-- "昨天" = ${new Date(Date.now() - 86400000).toISOString().split('T')[0]}
-- "前天" = ${new Date(Date.now() - 172800000).toISOString().split('T')[0]}
-- "最近" = 最近7天 (${new Date(Date.now() - 7 * 86400000).toISOString().split('T')[0]} ~ ${today})
-- "上周" = 上一个完整周(周一到周日)`;
+时间理解(以下日期已按本地时区算好,直接用,不要自己推算):
+- "今天" = ${t.today}
+- "昨天" = ${t.yesterday}
+- "前天" = ${t.dayBeforeYesterday}
+- "最近" = ${t.recentFrom} ~ ${t.today}(含今天共 7 天)
+- "上周" = ${t.lastWeekFrom} ~ ${t.lastWeekTo}(上一个完整周,周一到周日)
+- "本周" = ${t.thisWeekFrom} ~ ${t.today}
+
+工具已内置相对日期解析:问题里出现"上周""最近""昨天"这类表达时,可以省略
+dateFrom/dateTo,工具会自己算好并在 dateRange 字段回报实际用的区间。你也可以
+显式传日期覆盖它。`;
 
     // 预算闸门:每个 turn 对应一次 LLM 调用。达到上限后 runAgentLoop 在
     // turn_end 之后收尾退出,不再发起新调用——这是唯一的成本上限。

--- a/test/qa-tools.test.mjs
+++ b/test/qa-tools.test.mjs
@@ -489,3 +489,92 @@ test('旧索引无 aliases 字段时不崩溃（向后兼容）', async () => {
     );
     assert.ok(r.matchCount > 0, '旧索引应照常工作');
 });
+
+// ─── 相对日期在工具侧解析（原先靠 LLM 自己算，算错就静默搜错范围）────────
+// 语料：2026-09-01(周二) ~ 2026-09-08(周二)，每天一条可区分的消息
+function dayMsgs() {
+    const out = [];
+    for (let d = 1; d <= 8; d++) {
+        const ts = new Date(2026, 8, d, 10, 0, 0).getTime();
+        out.push({
+            id: String(9000 + d),
+            user: 'alice',
+            content: `第${d}天的话题 链接分享`,
+            timestamp: ts,
+            time: `2026/09/${String(d).padStart(2, '0')} 10:00:00`,
+        });
+    }
+    return out;
+}
+
+test('get_recent_messages 省略日期时，从问题解析「上周」', async () => {
+    // 用真实"今天"无法断言固定区间，所以断言的是「解析发生了」而非具体日期：
+    // dateNote 出现即证明工具替模型限定了范围，dateRange 回报了实际区间
+    const r = await executeTool(
+        'get_recent_messages',
+        {},
+        dayMsgs(),
+        ledger(),
+        null,
+        '上周分享过什么链接'
+    );
+    assert.ok(r.dateNote, '应回报自动限定的说明');
+    assert.match(r.dateNote, /上周/);
+    assert.match(r.dateNote, /\d{4}-\d{2}-\d{2} ~ \d{4}-\d{2}-\d{2}/, '说明里应含具体区间');
+});
+
+test('模型显式给的日期优先于问题里的相对表达', async () => {
+    const r = await executeTool(
+        'get_recent_messages',
+        { dateFrom: '2026-09-03', dateTo: '2026-09-04' },
+        dayMsgs(),
+        ledger(),
+        null,
+        '上周分享过什么链接' // 问题说"上周"，但模型显式给了 9/3-9/4
+    );
+    assert.strictEqual(r.dateRange, '2026-09-03 ~ 2026-09-04');
+    assert.strictEqual(r.dateNote, undefined, '显式传日期时不该自动覆盖');
+    assert.strictEqual(r.total, 2, '应只读到 9/3 与 9/4 两条');
+});
+
+test('问题无相对表达时不限定范围（不猜）', async () => {
+    const r = await executeTool(
+        'get_recent_messages',
+        {},
+        dayMsgs(),
+        ledger(),
+        null,
+        '谁在聊半导体'
+    );
+    assert.strictEqual(r.dateNote, undefined);
+    assert.strictEqual(r.total, 8, '未解析出相对表达时应读全部');
+});
+
+test('search_messages 也走同一套日期解析', async () => {
+    const r = await executeTool(
+        'search_messages',
+        { keywords: ['链接'] },
+        dayMsgs(),
+        ledger(),
+        null,
+        '昨天分享的链接'
+    );
+    // "昨天"必然落在语料外或内，两种都可接受；关键是解析发生并回报
+    assert.ok(r.dateNote, 'search_messages 应同样回报自动限定');
+    assert.match(r.dateNote, /昨天/);
+});
+
+test('count_messages 刻意不自动限定（它的用途是不限日期探测分布）', async () => {
+    // 自动限定会破坏 system prompt 教的"先宽后窄"策略：
+    // 先用 count_messages 探全量分布 → 再把 search_messages 锁到热点日期
+    const r = await executeTool(
+        'count_messages',
+        { keywords: ['话题'] },
+        dayMsgs(),
+        ledger(),
+        null,
+        '上周聊了什么话题'
+    );
+    assert.strictEqual(r.dateNote, undefined, 'count_messages 不该自动限定');
+    assert.strictEqual(r.total, 8, '应统计全部 8 天，而非只统计上周');
+});

--- a/test/relative-dates.test.js
+++ b/test/relative-dates.test.js
@@ -1,0 +1,115 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const {
+    resolveRelativeRange,
+    timeAnchors,
+    localDate,
+    startOfWeek,
+} = require('../lib/relative-dates');
+
+// 固定参照时刻：2026-09-08 是周二（用本地时区构造，与归档 time 字段同口径）
+const TUE = new Date(2026, 8, 8, 14, 30, 0); // 月份 0-based：8 = 九月
+
+test('localDate 用本地日期，不受 UTC 偏移影响', () => {
+    // UTC+8 的早上 07:00，toISOString() 会退到前一天
+    const morning = new Date(2026, 8, 8, 7, 0, 0);
+    assert.strictEqual(localDate(morning), '2026-09-08');
+});
+
+test('startOfWeek 以周一为一周之始，周日归上一周', () => {
+    assert.strictEqual(localDate(startOfWeek(new Date(2026, 8, 8))), '2026-09-07'); // 周二 → 周一
+    assert.strictEqual(localDate(startOfWeek(new Date(2026, 8, 7))), '2026-09-07'); // 周一 → 自身
+    assert.strictEqual(localDate(startOfWeek(new Date(2026, 8, 13))), '2026-09-07'); // 周日 → 本周一
+});
+
+test('昨天/前天/大前天/今天 解析为单日区间', () => {
+    for (const [q, d] of [
+        ['今天有人聊什么', '2026-09-08'],
+        ['昨天有讨论投资吗', '2026-09-07'],
+        ['前天说了什么', '2026-09-06'],
+        ['大前天呢', '2026-09-05'],
+    ]) {
+        const r = resolveRelativeRange(q, TUE);
+        assert.deepStrictEqual(
+            [r.dateFrom, r.dateTo],
+            [d, d],
+            `${q} 应解析为 ${d}，实际 ${r && r.dateFrom}`
+        );
+    }
+});
+
+test('上周 = 上一个完整周（周一到周日）—— 这是历史 benchmark 里搜错的那个', () => {
+    const r = resolveRelativeRange('上周分享过什么链接', TUE);
+    assert.strictEqual(r.dateFrom, '2026-08-31'); // 上周一
+    assert.strictEqual(r.dateTo, '2026-09-06'); // 上周日
+    assert.match(r.label, /上周/);
+});
+
+test('上上周不被「上周」前缀吞掉', () => {
+    const r = resolveRelativeRange('上上周聊了什么', TUE);
+    assert.strictEqual(r.dateFrom, '2026-08-24');
+    assert.strictEqual(r.dateTo, '2026-08-30');
+});
+
+test('本周至今不包含未来日期', () => {
+    const r = resolveRelativeRange('这周大家在聊什么', TUE);
+    assert.strictEqual(r.dateFrom, '2026-09-07'); // 本周一
+    assert.strictEqual(r.dateTo, '2026-09-08'); // 今天，而非本周日
+});
+
+test('最近 = 7 天含今天；最近 N 天优先于笼统的「最近」', () => {
+    const r = resolveRelativeRange('最近大家在聊什么话题', TUE);
+    assert.strictEqual(r.dateFrom, '2026-09-02'); // 含今天共 7 天
+    assert.strictEqual(r.dateTo, '2026-09-08');
+
+    const n = resolveRelativeRange('最近3天有什么事', TUE);
+    assert.strictEqual(n.dateFrom, '2026-09-06');
+    assert.strictEqual(n.dateTo, '2026-09-08');
+    assert.match(n.label, /3 天/);
+});
+
+test('上个月跨月边界正确（含当月天数不同的情况）', () => {
+    const r = resolveRelativeRange('上个月聊了什么', TUE);
+    assert.strictEqual(r.dateFrom, '2026-08-01');
+    assert.strictEqual(r.dateTo, '2026-08-31');
+
+    // 3 月 5 日问「上个月」应得 2 月，且 2026 非闰年 → 28 日
+    const mar = resolveRelativeRange('上个月呢', new Date(2026, 2, 5));
+    assert.strictEqual(mar.dateFrom, '2026-02-01');
+    assert.strictEqual(mar.dateTo, '2026-02-28');
+
+    // 1 月问「上个月」应跨年到去年 12 月
+    const jan = resolveRelativeRange('上个月呢', new Date(2026, 0, 10));
+    assert.strictEqual(jan.dateFrom, '2025-12-01');
+    assert.strictEqual(jan.dateTo, '2025-12-31');
+});
+
+test('边界模糊或无相对表达时返回 null（不猜）', () => {
+    // 猜错范围比不解析更有害：不解析时模型还能从 dateSpan 自己挑
+    for (const q of ['谁在聊半导体', '前几天的事', 'tk 说了什么', '']) {
+        assert.strictEqual(resolveRelativeRange(q, TUE), null, `"${q}" 不该被解析`);
+    }
+});
+
+test('timeAnchors 全部为本地日期，上周区间与 resolveRelativeRange 一致', () => {
+    const a = timeAnchors(TUE);
+    assert.strictEqual(a.today, '2026-09-08');
+    assert.strictEqual(a.yesterday, '2026-09-07');
+    assert.strictEqual(a.dayBeforeYesterday, '2026-09-06');
+    assert.strictEqual(a.recentFrom, '2026-09-02');
+
+    const r = resolveRelativeRange('上周', TUE);
+    assert.strictEqual(a.lastWeekFrom, r.dateFrom);
+    assert.strictEqual(a.lastWeekTo, r.dateTo);
+});
+
+test('清晨时段的锚点不偏移一天（UTC 偏移回归）', () => {
+    // 这是修复前的真实 bug：toISOString() 在 UTC+8 的 00:00-08:00 会退一天
+    const dawn = new Date(2026, 8, 8, 3, 0, 0);
+    const a = timeAnchors(dawn);
+    assert.strictEqual(a.today, '2026-09-08', '凌晨 3 点的"今天"仍应是 09-08');
+    assert.strictEqual(a.yesterday, '2026-09-07');
+});


### PR DESCRIPTION
## 动机

「上周」「最近」「昨天」原先只在 system prompt 里以**文字说明**存在：

```
- "上周" = 上一个完整周(周一到周日)
```

由 LLM 自己算成 `dateFrom`/`dateTo`。算错就**静默搜错范围** —— README 的历史 benchmark 里恰好记着一次真实翻车：

> 上周分享过什么链接 | Agent日期正确(6/15-21); **Legacy搜错周(6/8-14)**

依据 Chronos（[arXiv 2603.16862](https://arxiv.org/abs/2603.16862)，LongMemEval SOTA 95.6%）：把相对时间表达解析成结构化 datetime 区间交给检索侧过滤，而非让模型从字符串推断。其消融显示去掉日期过滤掉 **14.7 分**。论文的说法是把时间推理 *"from string interpretation to structured filtering"*。

## 🐛 顺带抓到一个更隐蔽的 bug（时区偏移）

提示词原先用 `new Date().toISOString()` 取「今天」—— 那是 **UTC 日期**，而归档消息的 `time` 字段是**本地时间**：

```
UTC+8 早上 07:00
  toISOString()   → 2026-09-07   ← 提示词说的"今天"
  归档 time 字段   → 2026-09-08   ← 实际今天的消息
```

**UTC+8 时区在每天 00:00–08:00 之间，提示词里的「今天/昨天/最近 7 天」全部偏移一天。** 早起的人问「昨天聊了什么」会拿到前天的记录。现在所有日期都走本地字段（`getFullYear`/`getMonth`/`getDate`），与归档 `time` 同一口径。

## 改动

新增 `lib/relative-dates.js`。`search_messages` 与 `get_recent_messages` 在模型**没给日期时**从问题原文解析：

| 表达 | 解析结果 |
|---|---|
| 今天 / 昨天 / 前天 / 大前天 | 单日区间 |
| 上周 / 上礼拜 | 上一个完整周（周一–周日） |
| 上上周 | 再往前一周 |
| 本周 / 这周 | 本周一 – 今天（不含未来） |
| 上个月 / 本月 | 自然月边界（跨年、非闰年 2 月正确） |
| 最近 / 近期 / 这几天 | 含今天共 7 天 |
| 最近 N 天 | 含今天共 N 天（1 ≤ N ≤ 365） |

同时提示词里的「上周」也改成给算好的具体区间，不再只给一句文字规则。

## 三条设计约束

| 约束 | 理由 |
|---|---|
| **模型显式给的日期优先** | 它可能有比问题字面更好的判断（例如前几轮已用 `count_messages` 探到热点日期） |
| **解析不出就不限定** | 「前几天」「最近一段时间」这类边界模糊的一律返回 `null` —— 猜错范围比不解析更有害，不解析时模型至少还能从 `dateSpan` 自己挑 |
| **`count_messages` 刻意不参与** | 它的用途正是「不限日期探测话题分布在哪些日期」，自动限定会破坏 prompt 里教的「先宽后窄」策略。**有专门的测试守着这条** |

工具在 `dateRange` 回报实际使用的区间，自动限定时附 `dateNote`，让模型知道范围是工具替它选的（而不是以为搜了全量）。

## 验证

**+16 测试（250 → 266）**

lib 层 11 个，其中几条挡的是真 bug：
- **凌晨时段锚点不偏移** —— 上述 UTC bug 的直接回归测试
- **上上周不被「上周」前缀吞掉** —— 正则顺序问题
- **周日归上一周** —— 中文语境以周一为周始
- **本周不含未来日期**、**上个月跨年 / 非闰年 2 月边界**

工具层 5 个：省略日期时自动解析并回报 `dateNote`、显式日期优先、无相对表达时不限定、`search_messages` 同样生效、**`count_messages` 不自动限定**。

**真机**：造 22 天跨三周语料，`bun build --compile` 出的 sidecar，mock 网关模拟模型「偷懒不传日期」只调 `get_recent_messages`，问「上周分享过什么链接」：

```
期望区间      : 2026-08-31 ~ 2026-09-06
工具实际用的  : 2026-08-31 ~ 2026-09-06
是否等于期望  : True
落在区间内条数: 7  (上周 7 天)
读到的日期    : 08-31 → 09-06 连续无偏移
```

`npm test` 266/266，lint 与 format:check 干净。

## 边界

- **`−14.7` 这个幅度不可迁移**。Chronos 测的是 LongMemEval（两方对话、个人事实随时间演变）；我们是多方群聊。可迁移的是「让确定性代码算日期、别让 LLM 猜」这个方向，不是具体数字。
- **只认高频无歧义的表达**。方言/口语变体（「头两天」「前阵子」）没覆盖，会退回不限定。
- 未在真实模型 + 真实归档上测过（无 API key 与归档数据）。要拿真实对比：`node scripts/benchmark-qa.js --group <群名> --repeat 3`。

按 [arXiv 2605.15184](https://arxiv.org/abs/2605.15184) 那条方法论警告（*"换 harness 的影响 ≈ 换检索器的影响"*），本 PR **只动日期这一样**，未同时改检索或 prompt 结构以外的东西。
