### PR TITLE
Sync README with the retrieval features shipped since #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,12 +256,16 @@ Ask questions in the toolbar's Q&A box; natural-language time ("recently", "yest
 
 💡 **If people go by nicknames, add an alias table**: create `output/<group>/aliases.json` with e.g. `{"tombkeeper": ["tk", "TK"]}` (keys are the real display names as archived). Asking "what did tk say recently" then filters straight to that person instead of making the LLM guess. The file is optional; without it behavior is unchanged.
 
-Retrieval automatically drops red-packet notices and check-in bot spam (same rules as the viewer's "hide noise" toggle), so "what is everyone talking about" isn't skewed by flooding.
+Retrieval automatically drops red-packet notices and check-in bot spam (same rules as the viewer's "hide noise" toggle) and collapses consecutive reposts, so "what is everyone talking about" isn't skewed by flooding. Asking about "last week" / "recently" / "yesterday" uses dates computed by the tools rather than inferred by the LLM. Shared links, videos and images are searchable too (asking "what links were shared last week" now finds them).
+
+💡 **For better recall, build the offline index once**: `node scripts/build-qa-index.mjs --group <group> --all`. It generates a summary plus a few reworded aliases per topic chunk, so a question phrased "who trimmed positions" can hit a message that says "sold half my chip stocks". It is incremental and resumable, and skips already-completed days on re-runs. Without it things still work — cross-vocabulary questions just lean more on the online rerank.
 
 <details>
 <summary><b>Technical design</b></summary>
 
-Uses the Agentic Search pattern. The tool loop comes from [`@mariozechner/pi-agent-core`](https://www.npmjs.com/package/@mariozechner/pi-agent-core)'s `runAgentLoop` (tool dispatch + argument validation + retry + timeout + provider adaptation); this repo keeps only the retrieval layer (bigram BM25 + topic-chunk index + LLM rerank), the prompts, and the budget gate (≤7 LLM calls). Structured state accumulation follows the LedgerAgent paper.
+Uses the Agentic Search pattern. The tool loop comes from [`@mariozechner/pi-agent-core`](https://www.npmjs.com/package/@mariozechner/pi-agent-core)'s `runAgentLoop` (tool dispatch + argument validation + retry + timeout + provider adaptation); this repo keeps only the retrieval layer, the prompts, and the budget gate (≤7 LLM calls). Structured state accumulation follows the LedgerAgent paper.
+
+Retrieval layer: topic-chunk splitting (30-minute gaps) → bigram BM25 → time decay (2-day half-life) → LLM rerank → in-chunk hit location. Plus three preprocessing passes: noise removal, speaker-alias resolution, and relative-date resolution ("last week" is computed into a concrete range by the tools rather than inferred by the LLM). An optional offline annotation layer also generates a summary and 2–4 reworded aliases per chunk, so a question phrased "who trimmed positions" can hit a chunk that says "sold half my chip stocks".
 
 Note: the AI proxy must support SSE streaming responses.
 
@@ -277,7 +281,7 @@ See [`docs/agent-qa.md`](docs/agent-qa.md) for details.
 | Search coverage | Multi-round expansion | Single pass |
 | Answer quality | High | Medium |
 
-⚠️ **These numbers are stale and not reproducible.** They predate the block-level BM25 retrieval rewrite and the pi-agent-core loop migration; the original harness lived in `eval/` (an agent scratch directory untracked in ee2a63d) and depended on private archive data. Treat the table as a directional record of why Agent mode is the default, not as a current measurement. Latency in particular should now be lower: the loop no longer pays fixed retry backoff and honors `Retry-After` (a 2×429 recovery measured 3011ms → 1407ms), so the figure is conservative rather than optimistic.
+⚠️ **These numbers are stale and not reproducible.** They predate the block-level BM25 retrieval rewrite and the pi-agent-core loop migration; the original harness lived in `eval/` (an agent scratch directory untracked in ee2a63d) and depended on private archive data. Treat the table as a directional record of why Agent mode is the default, not as a current measurement. Latency in particular should now be lower: the loop no longer pays fixed retry backoff (a 2×429 recovery measured 3011ms → 1407ms — the SDK's default jittered backoff versus the old fixed 1s+2s), so the figure is conservative rather than optimistic.
 
 For current numbers, run `node scripts/benchmark-qa.js --group <group>` against your own archive (see [`docs/agent-qa.md`](docs/agent-qa.md#benchmark-结果)).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -243,12 +243,16 @@ grep -c "Cookie 已失效" logs/archive.log   # 非 0 说明该重新扫码了
 
 💡 **群友有外号就写张别名表**：新建 `output/<群名>/aliases.json`，内容形如 `{"tombkeeper": ["tk", "TK"]}`（键是归档里的真实昵称）。这样问「tk 最近说了什么」就能直接筛到人，不必靠 LLM 自己猜。文件可选，缺失时行为不变。
 
-检索会自动剔除红包提示与签到机器人（规则同查看器的「隐藏噪音」），所以「大家在聊什么」不会被刷屏带偏。
+检索会自动剔除红包提示与签到机器人（规则同查看器的「隐藏噪音」），并折叠连续复读，所以「大家在聊什么」不会被刷屏带偏。问「上周」「最近」「昨天」时日期由工具算好，不靠 LLM 自己推。分享的链接、视频、图片也可检索（问「上周分享过什么链接」能直接搜到）。
+
+💡 **想让检索更准，建一次离线索引**：`node scripts/build-qa-index.mjs --group <群名> --all`。它为每个话题块生成摘要与几条同义改写，让「减持」这类提问也能命中写着「清了一半芯片股」的消息。增量可断点续传、重跑跳过已完成的；不建也能用，只是跨词汇时更依赖在线精排。
 
 <details>
 <summary><b>技术方案</b></summary>
 
-采用 Agentic Search 模式。工具循环由 [`@mariozechner/pi-agent-core`](https://www.npmjs.com/package/@mariozechner/pi-agent-core) 的 `runAgentLoop` 提供（工具分发 + 参数校验 + 重试 + 超时 + provider 适配），本仓只保留检索层（bigram BM25 + 话题块索引 + LLM 精排）、提示词与预算闸门（≤7 次 LLM 调用）。结构化状态累积参考 LedgerAgent 论文。
+采用 Agentic Search 模式。工具循环由 [`@mariozechner/pi-agent-core`](https://www.npmjs.com/package/@mariozechner/pi-agent-core) 的 `runAgentLoop` 提供（工具分发 + 参数校验 + 重试 + 超时 + provider 适配），本仓只保留检索层、提示词与预算闸门（≤7 次 LLM 调用）。结构化状态累积参考 LedgerAgent 论文。
+
+检索层：话题块切分（30 分钟断层）→ bigram BM25 → 时间衰减（半衰期 2 天）→ LLM 精排 → 块内定位命中点。外加三道预处理：噪音剔除、发言人别名解析、相对日期解析（「上周」在工具侧算成具体区间，不让 LLM 自己推）。可选的离线标注层还会为每个话题块生成摘要与 2–4 条同义改写，让「减持」这类提问也能命中写着「清了一半芯片股」的块。
 
 注意：AI 代理需支持 SSE 流式响应。
 
@@ -264,7 +268,7 @@ grep -c "Cookie 已失效" logs/archive.log   # 非 0 说明该重新扫码了
 | 搜索覆盖 | 多轮扩展 | 单次 |
 | 答案质量 | 高 | 中 |
 
-⚠️ **这组数字已过期且不可复现。** 它早于块级 BM25 检索重写与 pi-agent-core 迁移；原始脚本在 `eval/`（agent 工作目录，随 ee2a63d 一起 untrack 移除），且依赖私有归档数据。请把这张表当作「为什么 Agent 模式是默认」的方向性记录，而不是当前实测值。延迟一项现在应当更低：新循环不再付固定重试等待，并遵循 `Retry-After`（实测两次 429 的自愈 3011ms → 1407ms），所以偏保守而非偏乐观。
+⚠️ **这组数字已过期且不可复现。** 它早于块级 BM25 检索重写与 pi-agent-core 迁移；原始脚本在 `eval/`（agent 工作目录，随 ee2a63d 一起 untrack 移除），且依赖私有归档数据。请把这张表当作「为什么 Agent 模式是默认」的方向性记录，而不是当前实测值。延迟一项现在应当更低：新循环不再付固定重试等待（实测两次 429 的自愈 3011ms → 1407ms，这是 SDK 默认退避对比旧版固定 1s+2s 的结果），所以偏保守而非偏乐观。
 
 要拿当前数字，在自己的归档上跑 `node scripts/benchmark-qa.js --group <群名>`（详见 [`docs/agent-qa.md`](docs/agent-qa.md#benchmark-结果)）。
 


### PR DESCRIPTION
README 落后于代码四处，其中**一处是我自己留下的错误**。

## ① 纠正 `Retry-After` 措辞（自己的遗留错误）

我在 commit message 里纠正过这句，但**漏了 README**。原文：

> 新循环不再付固定重试等待，并遵循 `Retry-After`（实测两次 429 的自愈 3011ms → 1407ms）

这把两件事混成一句：1407ms 是实测的，但测的是 **OpenAI SDK 默认退避（带 jitter）** 对比旧版固定 `1s+2s`；我的 mock **没有返回 `Retry-After` 头**，所以「遵循 Retry-After」是读 SDK 代码得出的推断，未实测。现在只保留实测部分并注明对比对象。

## ② 技术方案段落补全检索管线

原文只写「bigram BM25 + 话题块索引 + LLM 精排」，漏了 #31/#33/#34 加的三道预处理（噪音剔除 / 发言人别名 / 相对日期解析）与离线标注层的同义改写。

## ③ 用户可见能力补三条

- 连续复读折叠
- 相对日期由工具算而非 LLM 推
- **分享的链接/视频/图片可检索** —— 「上周分享过什么链接」现在能搜到，这正是 README 历史 benchmark 里那道翻车的题

## ④ 补 `build-qa-index.mjs` 的使用提示

离线索引是能显著改善跨词汇召回的**可选**步骤，但此前只在 `docs/agent-qa.md` 里提过，README 读者不知道要跑它。

## 核实

逐条比对新写的声称与代码：

| 声称 | 代码位置 |
|---|---|
| 30 分钟断层 | `chat-chunks.js` `gapMs = 30 * 60 * 1000` |
| 半衰期 2 天 | `HALF_LIFE_MS = 2 * 86400000` |
| 折叠连续复读 | `collapseRepeats` |
| `--all` 可用 | `build-qa-index.mjs flag('all')` |
| 2–4 条同义改写 | 标注 prompt |
| ≤7 次 LLM 调用 | `MAX_LLM_CALLS = 7` |

纯文档改动，`npm test` 275/275、format:check 干净。