### PR TITLE
Skip the bundled Chromium download (~650 MB per install)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ For current numbers, run `node scripts/benchmark-qa.js --group <group>` against 
 | --- | --- |
 | 🖥 **macOS / Linux / WSL** | Archiver and viewer run cross-platform; scheduled-job installation is automatic on every platform (launchd / systemd / cron) |
 | 🟢 **Node.js 20+** | [brew install node](https://brew.sh) (macOS) / `apt install nodejs` (Linux) / [nodejs.org](https://nodejs.org) |
-| 🌐 **Google Chrome** | The archiver drives it for login and scraping; path is auto-detected |
+| 🌐 **Google Chrome** | The archiver drives it for login and scraping; path is auto-detected (or set `chromePath` in `config.json`). The project only ever uses your installed Chrome, so `package.json` sets `puppeteer.skipDownload` and `npm install` no longer pulls a ~650 MB bundled Chromium; if you do want the bundled one, install with `PUPPETEER_SKIP_DOWNLOAD=0 npm install` |
 | 📱 **Weibo account + mobile app** | First-time login to the web version requires scanning a QR code with the app |
 | 🦀 **Rust + Bun** | Desktop app only; `npm run desktop` installs them automatically |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -306,7 +306,7 @@ grep -c "Cookie 已失效" logs/archive.log   # 非 0 说明该重新扫码了
 | --- | --- |
 | 🖥 **macOS / Linux / WSL** | 归档与查看器跨平台运行；定时任务全平台自动安装（launchd / systemd / cron） |
 | 🟢 **Node.js 20+** | [brew install node](https://brew.sh)（macOS）/ `apt install nodejs`（Linux）/ [nodejs.org](https://nodejs.org) |
-| 🌐 **Google Chrome** | 归档器用它登录并抓取消息；路径自动探测 |
+| 🌐 **Google Chrome** | 归档器用它登录并抓取消息；路径自动探测（也可在 `config.json` 的 `chromePath` 指定）。项目只用系统已装的 Chrome，因此 `package.json` 里设了 `puppeteer.skipDownload`，`npm install` 不会再下载一份 ~650 MB 的 Chromium；确实想用自带 Chromium 的话，用 `PUPPETEER_SKIP_DOWNLOAD=0 npm install` 装回来 |
 | 📱 **微博账号 + 手机 App** | 首次需用 App 扫码登录网页版 |
 | 🦀 **Rust + Bun** | 仅桌面应用需要；`npm run desktop` 会自动安装 |
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "engines": {
         "node": ">=20"
     },
+    "puppeteer": {
+        "skipDownload": true
+    },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/alloevil/weibo-chat-auto.git"

--- a/test/chrome-path.test.js
+++ b/test/chrome-path.test.js
@@ -1,0 +1,91 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { resolveChromePath } = require('../lib/chrome-path.js');
+
+test('resolveChromePath: config.json 指定且文件存在时优先于平台探测', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'chrome-path-'));
+    const fake = path.join(tmp, 'my-chrome');
+    fs.writeFileSync(fake, '');
+    try {
+        assert.strictEqual(resolveChromePath(fake), fake);
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+});
+
+test('resolveChromePath: 平台探测优先于不存在的 config 路径,全落空才回退它', () => {
+    // 顺序是 config(存在) → 平台探测 → config(不存在时兜底) → 抛错。
+    // 兜底分支只在平台探测无结果时才走到,所以这里把 platform 顶成没有候选的值,
+    // 否则装了 Chrome 的机器上会命中 /usr/bin/google-chrome 而测不到这条。
+    const missing = path.join(os.tmpdir(), 'definitely-not-a-real-chrome-binary');
+    const origPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'aix', configurable: true });
+    try {
+        assert.strictEqual(resolveChromePath(missing), missing);
+    } finally {
+        Object.defineProperty(process, 'platform', {
+            value: origPlatform,
+            configurable: true,
+        });
+    }
+});
+
+test('resolveChromePath: 落空时抛错,而不是退回 puppeteer 自带 Chromium', () => {
+    // 这条是 package.json 里 puppeteer.skipDownload 成立的前提:
+    // 本项目从不依赖自带 Chromium,所以找不到系统 Chrome 必须显式报错,
+    // 让用户去装 Chrome 或填 chromePath——静默退回会让人以为在用自己的 Chrome。
+    const origPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'aix', configurable: true });
+    try {
+        assert.throws(() => resolveChromePath(''), /未找到 Chrome 可执行文件/);
+    } finally {
+        Object.defineProperty(process, 'platform', {
+            value: origPlatform,
+            configurable: true,
+        });
+    }
+});
+
+test('每个 puppeteer.launch 都自带 executablePath——这是 skipDownload 可以为 true 的前提', () => {
+    // 跳过 Chromium 下载(~650 MB)只在「所有 launch 都指定系统 Chrome」时安全。
+    // 若将来有人加了一处不传 executablePath 的 launch,它会去找不存在的自带
+    // Chromium,而且只在用户机器上炸——所以在这里挡住。
+    const pkg = require('../package.json');
+    assert.strictEqual(
+        pkg.puppeteer && pkg.puppeteer.skipDownload,
+        true,
+        'package.json 应保留 puppeteer.skipDownload'
+    );
+
+    const roots = ['lib', 'scripts'];
+    const files = [];
+    for (const root of roots) {
+        const dir = path.join(__dirname, '..', root);
+        for (const name of fs.readdirSync(dir)) {
+            if (/\.(js|mjs)$/.test(name)) files.push(path.join(dir, name));
+        }
+    }
+
+    const offenders = [];
+    for (const file of files) {
+        const src = fs.readFileSync(file, 'utf8');
+        let idx = src.indexOf('puppeteer.launch(');
+        while (idx !== -1) {
+            // 取 launch( 之后一段,检查参数对象里是否有 executablePath
+            const window = src.slice(idx, idx + 600);
+            if (!window.includes('executablePath')) {
+                offenders.push(path.basename(file));
+            }
+            idx = src.indexOf('puppeteer.launch(', idx + 1);
+        }
+    }
+
+    assert.deepStrictEqual(
+        offenders,
+        [],
+        `这些文件里的 puppeteer.launch 未指定 executablePath: ${offenders.join(', ')}`
+    );
+});


### PR DESCRIPTION
## 问题

本项目**从不使用** puppeteer 自带的 Chromium —— 每个 `puppeteer.launch` 都显式传 `executablePath` 指向系统 Chrome：

| 文件 | 行 |
|---|---|
| `scripts/auto-archive-simple.js` | 145 |
| `lib/browser-login.js` | 44 |
| `scripts/save-cookies.js` | 21 |
| `scripts/take-screenshot.js` | 14 |

但 `npm install` 仍会为每次 puppeteer 升级下载一整套 Chromium。发现于 #32 合并后 —— 我的 `~/.cache/puppeteer` 已经积到 **2.3 GB**。

## 实测（隔离 `PUPPETEER_CACHE_DIR` 后 `npm rebuild puppeteer`）

| 配置 | 缓存大小 |
|---|---|
| 无配置 | **652 MB** |
| `skipDownload` | **4 KB** |

两个 CI workflow（`ci.yml`、`release.yml`）都跑 `npm ci`，各付一次。

## 为什么不用 `.npmrc`

我最初建议的 `.npmrc` 方案**是错的**。puppeteer 25 的 `getConfiguration` 不再读 `npm_config_*`（核对 `src/getConfiguration.ts`），`.npmrc` 里的 `puppeteer_skip_download` 无效。

改用 `package.json` 的 `puppeteer.skipDownload` —— `package.json` 本身是 lilconfig 的 searchPlace 之一，**提交进仓库对所有用户和 CI 都生效**，无需各自设环境变量。

## 验证跳过下载后功能不受影响

在零自带 Chromium 的环境实测：

```
resolveChromePath('')                    → /usr/bin/google-chrome
puppeteer.launch({executablePath}) 起浏览器 → 成功
b.version()                              → Chrome/152.0.7977.64
加载页面并读回 DOM                        → ok
```

逃生舱也实测过：`PUPPETEER_SKIP_DOWNLOAD=0` → `skipDownload=false`，下载 967 MB。README 中英文都写了。

## 新增 `test/chrome-path.test.js`（4 条）

- `resolveChromePath` 三条优先级路径，其中**全落空时必须抛错而非静默退回自带 Chromium** —— 这正是 `skipDownload` 成立的前提
- **一条守卫**：扫 `lib`+`scripts` 里所有 `puppeteer.launch`，若有一处不传 `executablePath` 就失败

⚠️ 守卫做了负向验证：插入一处不带 `executablePath` 的 launch 后该测试**确实失败**（`未指定 executablePath: __probe-bad.js`）。不然它只是个永远通过的装饰。

顺带修了我自己写错的一条断言 —— 原以为 config 不存在时直接兜底返回，实际平台探测优先（`chrome-path.js:56` 在 `:61` 之前），装了 Chrome 的机器上会命中真 Chrome。

279/279 测试、lint、format 干净。